### PR TITLE
UE - Add placeholder image

### DIFF
--- a/blocks/video/_video.json
+++ b/blocks/video/_video.json
@@ -62,8 +62,8 @@
         {
           "component": "text",
           "valueType": "string",
-          "name": "placeholder_alt",
-          "label": "Placeholder Alt Text",
+          "name": "placeholder_imageAlt",
+          "label": "Placeholder Image Alt Text",
           "value": ""
         },
         {

--- a/component-models.json
+++ b/component-models.json
@@ -437,8 +437,8 @@
       {
         "component": "text",
         "valueType": "string",
-        "name": "placeholder_alt",
-        "label": "Placeholder Alt Text",
+        "name": "placeholder_imageAlt",
+        "label": "Placeholder Image Alt Text",
         "value": ""
       },
       {


### PR DESCRIPTION
## Add placeholder image to video block to improve performance score

## Test URLs and instructions -- There can be more than 1 set

Test: see Placeholder Image and Placeholder Alt Text fields in video block

- Before: https://main--extweb-academy--aemsites.aem.page/
- After: https://add-placeholder-image--extweb-academy--aemsites.aem.page/
