### PR TITLE
feat: add iframe block with configuration, styles, and functionality

### DIFF
--- a/blocks/iframe/_iframe.json
+++ b/blocks/iframe/_iframe.json
@@ -1,0 +1,35 @@
+{
+  "definitions": [
+    {
+      "title": "Iframe",
+      "id": "iframe",
+      "plugins": {
+        "xwalk": {
+          "page": {
+            "resourceType": "core/franklin/components/block/v1/block",
+            "template": {
+              "name": "Iframe",
+              "model": "iframe"
+            }
+          }
+        }
+      }
+    }
+  ],
+  "models": [
+    {
+      "id": "iframe",
+      "fields": [
+        {
+          "component": "text",
+          "valueType": "string",
+          "name": "iframeUrl",
+          "value": "",
+          "label": "iFrame URL",
+          "description": "Please provide a URL to an iFrame app."
+        }
+      ]
+    }
+  ],
+  "filters": []
+}

--- a/blocks/iframe/iframe.css
+++ b/blocks/iframe/iframe.css
@@ -1,0 +1,25 @@
+.iframe-container {
+  padding: 0;
+  min-height: 500px;
+}
+
+.iframe-container > div {
+  max-width: none;
+}
+
+.iframe-wrapper {
+  position: relative;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  min-height: 500px;
+  height: calc(100vh + 460px);
+}
+
+.iframe.block {
+  position: absolute;
+  margin: 0 var(--section-gutter-space);
+  border: 0;
+  inset: 0;
+  overflow: hidden;
+}

--- a/blocks/iframe/iframe.js
+++ b/blocks/iframe/iframe.js
@@ -1,0 +1,29 @@
+
+const getDefaultEmbed = (url) => `
+    <iframe src="${url.href}" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position:absolute;" allowfullscreen="" frameborder="0" 
+      scrolling="no" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" 
+      title="Content from ${url.hostname}" loading="lazy" height="100%" width="100%">
+    </iframe>`;
+
+const loadEmbed = (block, link) => {
+  if (block.classList.contains('embed-is-loaded')) {
+    return;
+  }
+
+  const url = new URL(link);
+  block.innerHTML = getDefaultEmbed(url);
+  block.classList.add('embed-is-loaded');
+};
+
+export default function decorate(block) {
+  const props = [...block.children].map((row) => row.firstElementChild);
+  const appUrl = props[0].textContent;
+
+  const observer = new IntersectionObserver((entries) => {
+    if (entries.some((e) => e.isIntersecting)) {
+      observer.disconnect();
+      loadEmbed(block, appUrl);
+    }
+  });
+  observer.observe(block);
+}

--- a/models/_section.json
+++ b/models/_section.json
@@ -55,6 +55,7 @@
         "cards",
         "columns",
         "fragment",
+	"iframe",
         "library-metadata",
         "video",
         "swipe-carousel"


### PR DESCRIPTION
- Introduced a new iframe block with JSON configuration for defining the block and its fields.
- Added CSS styles for iframe container and wrapper to ensure proper layout.
- Implemented JavaScript functionality to load iframe content dynamically when the block is in view.

<!-- Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after): -->
<!-- Feel free to delete options that are not relevant to your PR. -->

## Issue

Fixes #IssueID

## Description of what the PR is changing, including screenshots for clarity if needed.

**New**

- Added iFrame to be pulled in from content tree
- 
**Changed**

- _section.json with iframe

**Removed**

- nothing


## Test URLs and instructions -- There can be more than 1 set

> If applicable, also describe how the PR reviewer can verify your expected changes, including anything that should NOT change.

- Before: https://main--extweb-academy--aemsites.aem.page/
- After: https://BranchName--extweb-academy--aemsites.aem.page/
