### PR TITLE
Fix references to format field

### DIFF
--- a/blocks/video/_video.json
+++ b/blocks/video/_video.json
@@ -46,7 +46,7 @@
           "condition": {
             "==": [
               {
-                "var": "videoType"
+                "var": "Format"
               },
               "you-tube"
             ]
@@ -75,7 +75,7 @@
           "condition": {
             "==": [
               {
-                "var": "videoType"
+                "var": "Format"
               },
               "embed-code"
             ]

--- a/component-models.json
+++ b/component-models.json
@@ -421,7 +421,7 @@
         "condition": {
           "==": [
             {
-              "var": "videoType"
+              "var": "Format"
             },
             "you-tube"
           ]
@@ -450,7 +450,7 @@
         "condition": {
           "==": [
             {
-              "var": "videoType"
+              "var": "Format"
             },
             "embed-code"
           ]


### PR DESCRIPTION

## Fix references to Format field by videoURL and embedCode fields


- Before: https://main--extweb-academy--aemsites.aem.page/
- After: https://add-placeholder-image--extweb-academy--aemsites.aem.page/
