### PR TITLE
UE only css for iframe height

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -363,3 +363,13 @@ main .section.highlight {
   margin: 0;
   padding: 40px 0;
 }
+
+/* Styles for AEM Universal Editor mode */
+   html.adobe-ue-preview,
+   html.adobe-ue-edit {
+     height: unset;
+   
+     .iframe-wrapper {
+       height: auto;
+     }
+   }


### PR DESCRIPTION
<!-- Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after): -->
<!-- Feel free to delete options that are not relevant to your PR. -->

## Issue

Fixes #51 

## Description of what the PR is changing, including screenshots for clarity if needed.

**New**

- 

**Changed**

- added some CSS to styles.css that only is applied when in the UE.
I can see the fix via ?ref=51-iframe
<img width="1487" height="895" alt="image" src="https://github.com/user-attachments/assets/73cd0d7e-4894-413a-a7f3-e86529697438" />


**Removed**

- 


## Test URLs and instructions -- There can be more than 1 set

> If applicable, also describe how the PR reviewer can verify your expected changes, including anything that should NOT change.

- Before: https://main--extweb-academy--aemsites.aem.page/test
- After: https://51-iframe--extweb-academy--aemsites.aem.page/test
