### PR TITLE
Add back min-height for the iframe container

### DIFF
--- a/blocks/iframe/iframe.css
+++ b/blocks/iframe/iframe.css
@@ -1,5 +1,6 @@
 .iframe-container {
   padding: 0;
+  min-height: 500px
 }
 
 .iframe-container > div {


### PR DESCRIPTION
Add back min-height for the iframe container

- Before: https://main--extweb-academy--aemsites.aem.page/
- After: https://65-iframe-heigh--extweb-academy--aemsites.aem.page/test/iframe
