### PR TITLE
change all images to DM

### DIFF
--- a/blocks/columns/columns.js
+++ b/blocks/columns/columns.js
@@ -1,3 +1,5 @@
+import { decorateDMImagesWithRendition } from '../../scripts/scripts.js';
+
 export default function decorate(block) {
   const cols = [...block.firstElementChild.children];
   block.classList.add(`columns-${cols.length}-cols`);
@@ -15,4 +17,5 @@ export default function decorate(block) {
       }
     });
   });
+  decorateDMImagesWithRendition(block);
 }

--- a/blocks/custom-image/_custom-image.json
+++ b/blocks/custom-image/_custom-image.json
@@ -97,7 +97,8 @@
                 "valueType": "boolean",
                 "name": "disable-smartcrop",
                 "value": "true",
-                "label": "Disable Smart Crop"
+                "label": "Disable Smart Crop",
+                "description": "If toggled off, only 1st image is used and the others are ignored"
               },
               {
                 "component": "text",
@@ -105,6 +106,7 @@
                 "name": "aspectRatio",
                 "value": "",
                 "label": "Aspect Ratio",
+                "description": "Use format of width/height, e.g. 16/9",
                 "condition": {
                   "===": [
                     {

--- a/blocks/custom-image/custom-image.js
+++ b/blocks/custom-image/custom-image.js
@@ -5,7 +5,7 @@ import { decorateDMImagesWithRendition } from '../../scripts/scripts.js';
 export default async function decorate(block) {
   const pictures = [...block.querySelectorAll('picture')];
   const [
-    imgD, imgT, imgM, alt,
+    imageDefault, imageTablet, imageMobile, alt,
     imageRatio,
     modifiers,
     disableSmartCrop,
@@ -42,9 +42,9 @@ export default async function decorate(block) {
 
   const isDisable = getText(disableSmartCrop, 'false');
 
-  if (isDisable === 'false' && imgD && imgD.innerHTML.trim() !== '') {
+  if (isDisable === 'false' && imageDefault && imageDefault.innerHTML.trim() !== '') {
     await decorateDMImagesWithRendition(
-      imgD,
+      imageDefault,
       imageRatio,
       modifiers,
       disableSmartCrop,
@@ -54,9 +54,9 @@ export default async function decorate(block) {
       objectPosDiv,
       loadingValue,
     );
-    paragraph.appendChild(imgD);
-    imgT?.remove();
-    imgM?.remove();
+    paragraph.appendChild(imageDefault);
+    imageTablet?.remove();
+    imageMobile?.remove();
   } else {
     // eslint-disable-next-line no-inner-declarations
     function getImageSrc(wrapper) {
@@ -78,9 +78,9 @@ export default async function decorate(block) {
     }
 
     // Get sources from wrappers
-    const desktopSrc = getImageSrc(imgD);
-    let tabletSrc = getImageSrc(imgT);
-    let mobileSrc = getImageSrc(imgM);
+    const desktopSrc = getImageSrc(imageDefault);
+    let tabletSrc = getImageSrc(imageTablet);
+    let mobileSrc = getImageSrc(imageMobile);
 
     if (mobileSrc === null || mobileSrc === undefined) {
       mobileSrc = tabletSrc;

--- a/component-models.json
+++ b/component-models.json
@@ -389,7 +389,8 @@
         "valueType": "boolean",
         "name": "disable-smartcrop",
         "value": "true",
-        "label": "Disable Smart Crop"
+        "label": "Disable Smart Crop",
+        "description": "If toggled off, only 1st image is used and the others are ignored"
       },
       {
         "component": "text",
@@ -397,6 +398,7 @@
         "name": "aspectRatio",
         "value": "",
         "label": "Aspect Ratio",
+        "description": "Use format of width/height, e.g. 16/9",
         "condition": {
           "===": [
             {

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -75,23 +75,6 @@ async function loadFonts() {
  *
  * @param {HTMLElement} main - The main container element that includes the links to be processed.
  */
-export function decorateDMImages(main) {
-  main.querySelectorAll('a[href^="https://delivery-p"]').forEach((a) => {
-    const url = new URL(a.href.split('?')[0]);
-    if (url.hostname.endsWith('.adobeaemcloud.com')) {
-      const pictureEl = picture(
-        source({ srcset: `${url.href}?width=1400&quality=85&preferwebp=true`, type: 'image/webp', media: '(min-width: 992px)' }),
-        source({ srcset: `${url.href}?width=1320&quality=85&preferwebp=true`, type: 'image/webp', media: '(min-width: 768px)' }),
-        source({ srcset: `${url.href}?width=780&quality=85&preferwebp=true`, type: 'image/webp', media: '(min-width: 320px)' }),
-        source({ srcset: `${url.href}?width=1400&quality=85`, media: '(min-width: 992px)' }),
-        source({ srcset: `${url.href}?width=1320&quality=85`, media: '(min-width: 768px)' }),
-        source({ srcset: `${url.href}?width=780&quality=85`, media: '(min-width: 320px)' }),
-        img({ src: `${url.href}?width=1400&quality=85`, alt: a.innerText }),
-      );
-      a.replaceWith(pictureEl);
-    }
-  });
-}
 export async function decorateDMImagesWithRendition(
   image,
   imageRatio,
@@ -141,6 +124,7 @@ export async function decorateDMImagesWithRendition(
       src: originalHref.replace('/original', ''),
     });
 
+    // case: AEMaaCS DAM asset
     if (url.hostname.endsWith('.adobeaemcloud.com')) {
       if (imageRendition !== '' && isDisable === 'false') {
         let metaPath = url.pathname.replace('/original', '');
@@ -205,6 +189,7 @@ export async function decorateDMImagesWithRendition(
         imgEl.style.aspectRatio = 'auto';
         imgEl.style.objectPosition = 'initial';
       } else {
+        // case: Dynamic Media asset
         if (quality !== '') {
           const imgSrc = originalHref.replace('/original', '');
           imgEl.src = `${imgSrc}?${quality}`;


### PR DESCRIPTION
<!-- Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after): -->
<!-- Feel free to delete options that are not relevant to your PR. -->

## Issue

Fixes #115 

## Description of what the PR is changing, including screenshots for clarity if needed.

**New**
- 

**Changed**
<img width="523" height="679" alt="image" src="https://github.com/user-attachments/assets/54278f6e-659f-47b4-9c54-4fdfa8713cd1" />


- all 3 image selection options for choosing image pick from World bank's dynamic media or AEMaaCS assets.
- added helper text for some of the fields.
- Removed an outdated function

**Removed**

- 


## Test URLs and instructions -- There can be more than 1 set

> If applicable, also describe how the PR reviewer can verify your expected changes, including anything that should NOT change.

This page still shows the 3 images will swap out based on breakpoint at the bottom, when the block is just in a section. Resize the page to see 3 different images at 3 breakpoints:

- Before: https://main--extweb-academy--aemsites.aem.page/library/columns1
- After: https://115-cusomimg--extweb-academy--aemsites.aem.page/library/columns1

This page shows that the 1 mage is indeed rendered when in a columns, but more work needs to be done on the columns block in another ticket to deal with the UE data items that are showing under the image.

- Before: https://main--extweb-academy--aemsites.aem.page/library/columns
- After: https://115-cusomimg--extweb-academy--aemsites.aem.page/library/columns
