### PR TITLE
Fix issue with content not loading completely for template marked pages.

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -325,9 +325,7 @@ export function decorateMain(main) {
  */
 async function loadTemplate(doc, templateName) {
   try {
-    const cssLoaded = new Promise((resolve) => {
-      loadCSS(`${window.hlx.codeBasePath}/templates/${templateName}/${templateName}.css`, resolve);
-    });
+    const cssLoaded = loadCSS(`${window.hlx.codeBasePath}/templates/${templateName}/${templateName}.css`);
     const decorationComplete = new Promise((resolve) => {
       (async () => {
         try {


### PR DESCRIPTION
The issue was in the loadTemplate function. The loadCSS function returns a Promise, but in loadTemplate, it's being incorrectly wrapped in another Promise and passing resolve as if it were a callback parameter - but loadCSS doesn't accept a callback parameter, it returns a Promise!
This causes the cssLoaded promise to never resolve, which makes Promise.all hang forever.

## Issue

Fixes #118 

## Description of what the PR is changing, including screenshots for clarity if needed.

**New**

- 

**Changed**

- 

**Removed**

- 


## Test URLs and instructions -- There can be more than 1 set

> If applicable, also describe how the PR reviewer can verify your expected changes, including anything that should NOT change.

- Before: https://main--extweb-academy--aemsites.aem.page/en/our-programs/by-theme
- After: https://118-template-functionality--extweb-academy--aemsites.aem.page/en/our-programs/by-theme
