### PR TITLE
hacky fix for preventing nav sections under page in the UE

### DIFF
--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -296,6 +296,21 @@ function toggleThreeDotsMenu(nav, forceExpanded = null) {
 // Swapna-mobile: end - toggleThreeDotsMenu function
 
 /**
+ * Recursively removes all data-aue-* attributes from an element and its descendants
+ * This is a hacky fix we seem to need for SP21 and SP23
+ * @param {Element} element The element to strip attributes from
+ */
+function stripAueAttributes(element) {
+  // Remove data-aue-* attributes from this element
+  [...element.attributes]
+    .filter((attr) => attr.name.startsWith('data-aue-'))
+    .forEach((attr) => element.removeAttribute(attr.name));
+
+  // Recursively strip from all children
+  Array.from(element.children).forEach((child) => stripAueAttributes(child));
+}
+
+/**
  * loads and decorates the header, mainly the nav
  * @param {Element} block The header block element
  */
@@ -309,7 +324,13 @@ export default async function decorate(block) {
   block.textContent = '';
   const nav = document.createElement('nav');
   nav.id = 'nav';
-  while (fragment.firstElementChild) nav.append(fragment.querySelector(':scope .section'));
+  if (fragment) {
+    // prevent header content from appearing in UE tree
+    stripAueAttributes(fragment);
+
+    // Append all sections from fragment
+    while (fragment.firstElementChild) { nav.append(fragment.firstElementChild); }
+  }
 
   const classes = ['brand', 'sections', 'tools', 'links'];
   classes.forEach((c, i) => {


### PR DESCRIPTION
<!-- Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after): -->
<!-- Feel free to delete options that are not relevant to your PR. -->

## Issue

Fixes #130 

## Description of what the PR is changing, including screenshots for clarity if needed.

**New**

- 

**Changed**

- 
<img width="597" height="417" alt="image" src="https://github.com/user-attachments/assets/8b9bfcae-1ce9-4fb9-8647-baddfaf17745" />


**Removed**

- 
<img width="628" height="494" alt="image" src="https://github.com/user-attachments/assets/06d67e4b-a834-46a2-af6c-eafbfc88f020" />



## Test URLs and instructions -- There can be more than 1 set

> If applicable, also describe how the PR reviewer can verify your expected changes, including anything that should NOT change.

- Before: https://main--extweb-academy--aemsites.aem.page/en/by-theme
- After: https://ue-headersections--extweb-academy--aemsites.aem.page/en/by-theme
