### PR TITLE
remove the stripAueAttributes

### DIFF
--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -415,21 +415,6 @@ function toggleThreeDotsMenu(nav, forceExpanded = null) {
 // Swapna-mobile: end - toggleThreeDotsMenu function
 
 /**
- * Recursively removes all data-aue-* attributes from an element and its descendants
- * This is a hacky fix we seem to need for SP21 and SP23
- * @param {Element} element The element to strip attributes from
- */
-function stripAueAttributes(element) {
-  // Remove data-aue-* attributes from this element
-  [...element.attributes]
-    .filter((attr) => attr.name.startsWith('data-aue-'))
-    .forEach((attr) => element.removeAttribute(attr.name));
-
-  // Recursively strip from all children
-  Array.from(element.children).forEach((child) => stripAueAttributes(child));
-}
-
-/**
  * loads and decorates the header, mainly the nav
  * @param {Element} block The header block element
  */
@@ -456,13 +441,7 @@ export default async function decorate(block) {
     nav.classList.add('nav-home');
   }
 
-  if (fragment) {
-    // prevent header content from appearing in UE tree
-    stripAueAttributes(fragment);
-
-    // Append all sections from fragment
-    while (fragment.firstElementChild) { nav.append(fragment.firstElementChild); }
-  }
+  while (fragment.firstElementChild) { nav.append(fragment.firstElementChild); }
 
   // Process home nav structure - add search icon and mobile support
   if (isHomeNav) {


### PR DESCRIPTION
<!-- Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after): -->
<!-- Feel free to delete options that are not relevant to your PR. -->

## Issue

Fixes #130

## Description of what the PR is changing, including screenshots for clarity if needed.

**New**

- 

**Changed**

- 

**Removed**

- The code I just removed was added as an attempt to fix extra fragment content from showing on their parent pages. It didn't really work, and now I've found that adding cq:Page as a resourceType of the "franklin-rewrite" sling rewriter in AEM is fixing the issue.


## Test URLs and instructions -- There can be more than 1 set

> If applicable, also describe how the PR reviewer can verify your expected changes, including anything that should NOT change.

- Before: https://main--extweb-academy--aemsites.aem.page/
- After: https://revert-hack--extweb-academy--aemsites.aem.page/
