### PR TITLE
fix: increase header z-index to prevent eyebrow overlap on mobile menu

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -2,7 +2,7 @@
 header .nav-wrapper {
   background-color: var(--background-color);
   width: 100%;
-  z-index: 2;
+  z-index: 100;
   position: fixed;
 }
 


### PR DESCRIPTION
## Issue

Fixes #160

The header nav-wrapper z-index was set to 2, which caused it to be
at the same stacking level as page content elements like the 
swipe-carousel eyebrow badges. This resulted in the eyebrow overlapping
the mobile menu.

Increased header z-index to 100 to establish proper stacking hierarchy:
- Overlays (1000+): megamenus, modals
- Fixed headers (100-999): navigation
- Page content (1-10): cards, carousels, badges

This ensures the fixed header always appears above regular page content
while remaining below overlay elements.

- Before: https://main--extweb-academy--aemsites.aem.page/
- After: https://160-bug-eyebrow--extweb-academy--aemsites.aem.page/
