### PR TITLE
fix(header): make :search: icon required for nav-home

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -1373,6 +1373,38 @@ body:has(.header-home nav.nav-home[aria-expanded='true']) {
   display: none;
 }
 
+/* Mobile icons container - shows all icons from third column on mobile */
+.header-home .mobile-icons-container {
+  display: flex;
+  order: 2;
+  align-items: center;
+  gap: 16px;
+}
+
+.header-home .mobile-icons-container .icon,
+.header-home .mobile-icons-container a {
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+}
+
+.header-home .mobile-icons-container .icon {
+  width: 22px;
+  height: 22px;
+}
+
+.header-home .mobile-icons-container .icon img {
+  width: 100%;
+  height: 100%;
+  filter: brightness(0) invert(1);
+}
+
+.header-home .mobile-icons-container .icon:hover {
+  opacity: 0.8;
+}
+
 /* Style mobile-nav-links (cloned third column) in mobile menu panel */
 .header-home .mobile-menu-panel .mobile-nav-links {
   display: flex;
@@ -1390,24 +1422,16 @@ body:has(.header-home nav.nav-home[aria-expanded='true']) {
   align-items: flex-start;
 }
 
+/* Show all list items in mobile menu panel */
 .header-home .mobile-menu-panel .mobile-nav-links ul li {
+  display: block;
   margin: 0;
   padding: 0;
 }
 
-.header-home .mobile-search-trigger .lp-search {
-  font-family: loopicon, monospace;
-  font-style: normal;
-  font-weight: normal;
-  font-size: 18px;
-  color: var(--white);
-  line-height: 1;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
+/* Hide search icons in mobile menu panel (we only want them in desktop nav-links or mobile trigger) */
 .header-home .mobile-menu-panel .mobile-nav-links ul li:has(.icon-search),
-.header-home .mobile-menu-panel .mobile-nav-links .lp-search,
+.header-home .mobile-menu-panel .mobile-nav-links .icon-search,
 .header-home .mobile-menu-panel .mobile-nav-links .icon {
   display: none;
 }
@@ -1501,18 +1525,6 @@ body:has(.header-home nav.nav-home[aria-expanded='true']) {
   font-weight: 700;
 }
 
-.header-home .mobile-search-trigger {
-  display: flex;
-  order: 2;
-}
-
-.header-home .mobile-search-trigger .lp-search::before {
-  content: "\e132";
-}
-
-.header-home .mobile-search-trigger .lp-search:hover {
-  opacity: 0.8;
-}
 
 .header-home .mobile-menu-panel {
   display: none;
@@ -1546,7 +1558,7 @@ body:has(.header-home nav.nav-home[aria-expanded='true']) {
 }
 
 .header-home nav.nav-home[aria-expanded='true'] .nav-brand,
-.header-home nav.nav-home[aria-expanded='true'] .mobile-search-trigger,
+.header-home nav.nav-home[aria-expanded='true'] .mobile-icons-container,
 .header-home nav.nav-home[aria-expanded='true'] .nav-hamburger {
   display: flex;
 }
@@ -1615,14 +1627,33 @@ body:has(.header-home nav.nav-home[aria-expanded='true']) {
 .header-home .home-search-btn {
   background: transparent;
   border: none;
-  color: #ec553a;
-  font-size: 18px;
   padding: 8px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.header-home .home-search-btn .icon-search {
+  width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.header-home .home-search-btn .icon-search img {
+  width: 100%;
+  height: 100%;
+  filter: brightness(0) saturate(100%) invert(38%) sepia(82%) saturate(2234%) hue-rotate(344deg) brightness(97%) contrast(88%);
 }
 
 .header-home .home-search-btn:hover {
   background: transparent;
-  color: #ec553a;
+}
+
+.header-home .home-search-btn:hover .icon-search img {
+  opacity: 0.8;
 }
 
 @media (width >= 400px) {
@@ -1648,8 +1679,9 @@ body:has(.header-home nav.nav-home[aria-expanded='true']) {
     padding: 16px 24px;
   }
 
-  .header-home .mobile-search-trigger .lp-search {
-    font-size: 20px;
+  .header-home .home-nav-links .icon-search {
+    width: 24px;
+    height: 24px;
   }
 
   .header-home .home-search-dropdown {
@@ -1699,9 +1731,8 @@ body:has(.header-home nav.nav-home[aria-expanded='true']) {
 
 @media (width >= 1281px) {
   .header-home .nav-hamburger,
-  .header-home .nav-three-dots,
-  .header-home .mobile-search-trigger {
-    display: none !important;
+  .header-home .nav-three-dots {
+    display: none;
   }
 
   .header-home nav.nav-home {
@@ -1783,6 +1814,7 @@ body:has(.header-home nav.nav-home[aria-expanded='true']) {
     margin: 0;
   }
 
+  /* Desktop: Show full nav-links */
   .header-home .home-nav-links {
     flex: 1 1 auto;
     display: flex;
@@ -1790,6 +1822,44 @@ body:has(.header-home nav.nav-home[aria-expanded='true']) {
     justify-content: flex-end;
     margin-left: auto;
     gap: 0;
+    position: static;
+    top: auto;
+    right: auto;
+    width: auto;
+    height: auto;
+  }
+
+  /* Desktop: Show the UL as flex container and show all list items */
+  .header-home .home-nav-links ul {
+    display: flex;
+    align-items: center;
+    list-style: none;
+    margin: 0 0 0 56px;
+    padding: 0;
+  }
+
+  .header-home .home-nav-links ul li {
+    display: flex;
+    margin-left: 24px;
+    padding: 0;
+    white-space: nowrap;
+    align-items: center;
+  }
+
+  .header-home .home-nav-links ul li:first-child {
+    margin-left: 0;
+  }
+
+  .header-home .home-nav-links ul li:last-child {
+    margin-left: 32px;
+  }
+
+  /* Desktop: Reset search icon sizing and styling */
+  .header-home .home-nav-links .icon-search {
+    width: 18px;
+    height: 18px;
+    cursor: pointer;
+    transition: opacity 0.3s ease;
   }
 
   .header-home .home-nav-links p {
@@ -1805,7 +1875,25 @@ body:has(.header-home nav.nav-home[aria-expanded='true']) {
   }
 
   /* Hide footer paragraph on desktop (only for mobile menu) */
-  .header-home .home-nav-links > p {
+  .header-home .home-nav-links > p:not(:has(.icon)) {
+    display: none;
+  }
+
+  /* Show paragraphs with icons */
+  .header-home .home-nav-links > p:has(.icon) {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 0;
+  }
+
+  /* If paragraph only contains an icon (no text), treat it as icon-only */
+  .header-home .home-nav-links > p:has(.icon):not(:has(a)) {
+    width: auto;
+  }
+
+  /* Hide icon-only paragraphs if the icon also appears in the list */
+  .header-home .home-nav-links:has(ul .icon-search) > p:has(.icon-search):not(:has(a)) {
     display: none;
   }
 
@@ -1829,54 +1917,46 @@ body:has(.header-home nav.nav-home[aria-expanded='true']) {
     color: rgb(255 255 255 / 80%);
   }
 
-  .header-home .home-nav-links ul {
-    display: flex;
-    align-items: center;
-    list-style: none;
-    margin: 0 0 0 56px;
-    padding: 0;
-  }
-
-  .header-home .home-nav-links ul li {
-    margin-left: 24px;
-    padding: 0;
-    white-space: nowrap;
-    display: flex;
-    align-items: center;
-  }
-
-  .header-home .home-nav-links ul li:first-child {
-    margin-left: 0;
-  }
-
-  .header-home .home-nav-links ul li:last-child {
-    margin-left: 32px;
-  }
-
+  /* Desktop home nav links: Show all icons (including search) */
   .header-home .home-nav-links .icon {
-    display: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 18px;
+    margin-right: 8px;
   }
 
-  .header-home .home-nav-links .lp-search {
-    font-family: loopicon, monospace;
-    font-style: normal;
-    font-weight: normal;
-    line-height: 1;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    color: rgb(255 255 255 / 75%);
-    font-size: 18px;
-    cursor: pointer;
-    transition: color 0.3s ease;
+  /* Remove margin from last icon in a group */
+  .header-home .home-nav-links .icon:last-child,
+  .header-home .home-nav-links li:has(a) .icon {
+    margin-right: 0;
   }
 
-  .header-home .home-nav-links .lp-search::before {
-    content: "\e132";
+  .header-home .home-nav-links .icon img {
+    width: 100%;
+    height: 100%;
   }
 
-  .header-home .home-nav-links .lp-search:hover,
-  .header-home .home-nav-links .lp-search.active {
-    color: var(--white);
+  /* Search icon specific styling */
+  .header-home .home-nav-links .icon-search img {
+    filter: brightness(0) invert(1);
+    opacity: 0.75;
+  }
+
+  .header-home .home-nav-links .icon-search:hover img,
+  .header-home .home-nav-links .icon-search.active img {
+    opacity: 1;
+  }
+
+  /* Other icons (like :home:) styling */
+  .header-home .home-nav-links .icon:not(.icon-search) img {
+    filter: brightness(0) invert(1);
+    opacity: 0.75;
+  }
+
+  .header-home .home-nav-links .icon:not(.icon-search):hover img {
+    opacity: 1;
   }
 
   .header-home .home-search-dropdown {
@@ -1893,17 +1973,23 @@ body:has(.header-home nav.nav-home[aria-expanded='true']) {
     padding-bottom: 8px;
   }
 
-  .header-home .home-search-btn {
-    font-family: loopicon, monospace;
-    font-size: 24px;
-    color: #003e7e;
+  .header-home .home-search-btn .icon-search {
+    width: 24px;
+    height: 24px;
   }
 
-  .header-home .home-search-btn::before {
-    content: "\e132";
+  .header-home .home-search-btn .icon-search img {
+    filter: brightness(0) saturate(100%) invert(14%) sepia(94%) saturate(2819%) hue-rotate(204deg) brightness(91%) contrast(102%);
   }
 
-  .header-home .home-search-btn:hover {
-    color: #003e7e;
+  .header-home .home-search-btn:hover .icon-search img {
+    opacity: 0.8;
+  }
+
+  /* Hide mobile-only elements on desktop */
+  .header-home .nav-hamburger,
+  .header-home .nav-three-dots,
+  .header-home .mobile-icons-container {
+    display: none !important;
   }
 }

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -1,4 +1,4 @@
-import { getMetadata } from '../../scripts/aem.js';
+import { getMetadata, decorateIcons } from '../../scripts/aem.js';
 import { loadFragment } from '../fragment/fragment.js';
 import { countryList } from './country-list.js';
 
@@ -37,7 +37,7 @@ function closeHomeSearchDropdown() {
   dropdown.classList.remove('open');
   dropdown.setAttribute('aria-hidden', 'true');
 
-  const searchIcon = document.querySelector('.header-home .lp-search');
+  const searchIcon = document.querySelector('.header-home .icon-search');
   if (searchIcon) {
     searchIcon.classList.remove('active');
   }
@@ -54,7 +54,7 @@ function closeHomeSearchDropdown() {
  */
 function handleClickOutside(e) {
   const dropdown = document.querySelector('.home-search-dropdown');
-  if (dropdown && !dropdown.contains(e.target) && !e.target.closest('.lp-search')) {
+  if (dropdown && !dropdown.contains(e.target) && !e.target.closest('.icon-search')) {
     closeHomeSearchDropdown();
     document.removeEventListener('click', handleClickOutside);
   }
@@ -86,9 +86,19 @@ function openHomeSearchDropdown() {
   input.setAttribute('aria-label', 'Search Academy');
 
   const searchBtn = document.createElement('button');
-  searchBtn.className = 'home-search-btn lp lp-search';
+  searchBtn.className = 'home-search-btn';
   searchBtn.setAttribute('aria-label', 'Submit search');
   searchBtn.type = 'button';
+
+  // Create search icon using EDS icon structure
+  const searchBtnIcon = document.createElement('span');
+  searchBtnIcon.className = 'icon icon-search';
+  const searchBtnImg = document.createElement('img');
+  searchBtnImg.src = `${window.hlx.codeBasePath}/icons/search.svg`;
+  searchBtnImg.alt = '';
+  searchBtnImg.loading = 'lazy';
+  searchBtnIcon.appendChild(searchBtnImg);
+  searchBtn.appendChild(searchBtnIcon);
 
   const performSearch = () => {
     const query = input.value.trim();
@@ -119,7 +129,7 @@ function openHomeSearchDropdown() {
     input.focus();
   });
 
-  const searchIcon = document.querySelector('.header-home .lp-search');
+  const searchIcon = document.querySelector('.header-home .icon-search');
   if (searchIcon) {
     searchIcon.classList.add('active');
   }
@@ -488,12 +498,18 @@ export default async function decorate(block) {
         const thirdColumn = columns[2];
         thirdColumn.classList.add('home-nav-links');
 
-        // Find and convert the manually authored :search: icon to loopicon font
-        const searchIconWrapper = thirdColumn.querySelector('.icon-search');
-        if (searchIconWrapper) {
-          // Replace SVG icon with loopicon font-based icon
-          const searchIcon = document.createElement('span');
-          searchIcon.className = 'lp lp-search';
+        // Decorate icons in the third column if not already decorated
+        // Check if icons already have img elements (already decorated by EDS)
+        const iconsAlreadyDecorated = thirdColumn.querySelector('.icon img');
+        if (!iconsAlreadyDecorated) {
+          decorateIcons(thirdColumn);
+        }
+
+        // Find all search icons (EDS decorated) and add click handlers
+        const searchIcons = thirdColumn.querySelectorAll('.icon-search');
+
+        searchIcons.forEach((searchIcon) => {
+          // Make the icon clickable and accessible
           searchIcon.setAttribute('role', 'button');
           searchIcon.setAttribute('tabindex', '0');
           searchIcon.setAttribute('aria-label', 'Search');
@@ -512,38 +528,69 @@ export default async function decorate(block) {
               toggleHomeSearchDropdown();
             }
           });
+        });
 
-          // Replace the SVG icon with the font icon
-          searchIconWrapper.parentNode.replaceChild(searchIcon, searchIconWrapper);
+        // Create mobile icons container (shows all icons from third column on mobile)
+        const mobileIconsContainer = document.createElement('div');
+        mobileIconsContainer.className = 'mobile-icons-container';
+        mobileIconsContainer.setAttribute('role', 'navigation');
+        mobileIconsContainer.setAttribute('aria-label', 'Quick actions');
+
+        // Find ALL icons in the third column
+        const allIcons = thirdColumn.querySelectorAll('.icon');
+
+        allIcons.forEach((icon) => {
+          // Clone the icon for mobile use
+          const mobileIcon = icon.cloneNode(true);
+
+          // If it's a search icon, add special handlers
+          if (mobileIcon.classList.contains('icon-search')) {
+            mobileIcon.setAttribute('role', 'button');
+            mobileIcon.setAttribute('tabindex', '0');
+            mobileIcon.setAttribute('aria-label', 'Search');
+
+            mobileIcon.addEventListener('click', (e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              toggleHomeSearchDropdown();
+            });
+
+            mobileIcon.addEventListener('keydown', (e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                toggleHomeSearchDropdown();
+              }
+            });
+          } else {
+            // For other icons (like home), check if they're in a link
+            const parentListItem = icon.closest('li');
+            if (parentListItem) {
+              const link = parentListItem.querySelector('a');
+              if (link) {
+                // Wrap the icon in a link
+                const mobileLink = document.createElement('a');
+                mobileLink.href = link.href;
+                mobileLink.setAttribute('aria-label', link.textContent.trim() || 'Link');
+                mobileLink.appendChild(mobileIcon);
+                mobileIconsContainer.appendChild(mobileLink);
+                return; // Skip adding the bare icon
+              }
+            }
+
+            // If no link found, make it a button (in case it has other functionality)
+            mobileIcon.setAttribute('role', 'button');
+            mobileIcon.setAttribute('tabindex', '0');
+          }
+
+          mobileIconsContainer.appendChild(mobileIcon);
+        });
+
+        // Only add the container if there are icons
+        if (allIcons.length > 0) {
+          nav.appendChild(mobileIconsContainer);
         }
       }
     }
-
-    // Create mobile search trigger (for mobile/tablet views)
-    const mobileSearchTrigger = document.createElement('div');
-    mobileSearchTrigger.className = 'mobile-search-trigger';
-
-    const mobileSearchIcon = document.createElement('span');
-    mobileSearchIcon.className = 'lp lp-search';
-    mobileSearchIcon.setAttribute('role', 'button');
-    mobileSearchIcon.setAttribute('tabindex', '0');
-    mobileSearchIcon.setAttribute('aria-label', 'Search');
-
-    mobileSearchIcon.addEventListener('click', (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      toggleHomeSearchDropdown();
-    });
-
-    mobileSearchIcon.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter' || e.key === ' ') {
-        e.preventDefault();
-        toggleHomeSearchDropdown();
-      }
-    });
-
-    mobileSearchTrigger.appendChild(mobileSearchIcon);
-    nav.appendChild(mobileSearchTrigger);
 
     // Create mobile menu panel for home navigation
     const mobileMenuPanel = document.createElement('div');


### PR DESCRIPTION
Nav-home header now requires manual :search: authoring in Column 3 instead of automatically adding it. This ensures proper alignment and consistent behavior with standard nav.

## Issue

Fixes #135 

- Before: https://main--extweb-academy--aemsites.aem.page/
- After: https://nav-home-search--extweb-academy--aemsites.aem.page/
