### PR TITLE
Add page property for 'template'

### DIFF
--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -153,34 +153,6 @@ function setup() {
 }
 
 /**
- * Checks for template override in page properties and injects it as a meta tag.
- * This allows page-level template to override metadata spreadsheet value.
- */
-async function applyTemplateOverride() {
-  try {
-    const pagePath = window.location.pathname;
-    const jsonUrl = pagePath.endsWith('/') ? `${pagePath}index.json` : `${pagePath}.json`;
-    const response = await fetch(jsonUrl);
-
-    if (response.ok) {
-      const json = await response.json();
-      // If page property has template defined, override the meta tag
-      if (json.template) {
-        let metaTag = document.querySelector('meta[name="template"]');
-        if (!metaTag) {
-          metaTag = document.createElement('meta');
-          metaTag.setAttribute('name', 'template');
-          document.head.appendChild(metaTag);
-        }
-        metaTag.setAttribute('content', json.template);
-      }
-    }
-  } catch (error) {
-    // Silently fail - spreadsheet value will be used
-  }
-}
-
-/**
  * Auto initialization.
  */
 
@@ -760,7 +732,6 @@ async function loadSections(element) {
 init();
 
 export {
-  applyTemplateOverride,
   buildBlock,
   createOptimizedPicture,
   decorateBlock,

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1,5 +1,4 @@
 import {
-  applyTemplateOverride,
   loadHeader,
   loadFooter,
   buildBlock,
@@ -451,8 +450,6 @@ async function loadTemplate(doc, templateName) {
  */
 async function loadEager(doc) {
   document.documentElement.lang = 'en';
-  // Apply template override from page properties before decorating
-  await applyTemplateOverride();
   decorateTemplateAndTheme();
   const main = doc.querySelector('main');
   if (main) {


### PR DESCRIPTION
## Issue

Fixes #179 

Add a text component for "template" that someone could type into.
(such as "program-details").

This would override a value coming from the metadata spreadsheet.

- Before: https://main--extweb-academy--aemsites.aem.page/en/cross-cutting/data/manage-successful-field-research
- After: https://179-page-property--extweb-academy--aemsites.aem.page/en/cross-cutting/data/manage-successful-field-research
