### PR TITLE
Wide template styles

### DIFF
--- a/templates/wide/wide.css
+++ b/templates/wide/wide.css
@@ -11,14 +11,14 @@
   padding-right: var(--grid-margin);
 }
 
-.wide main > .section:first-of-type > div {
-  padding-left: 0;
-  padding-right: 0;
-}
-
 .wide main > .section:first-of-type > div > h1 {
   margin-top: var(--spacing-xlarge);
   margin-bottom: var(--spacing-medium);
+}
+
+.wide main > .section .default-content-wrapper p {
+    font-size: 16px;
+    line-height: 1.5;
 }
 
 .wide main > .section:first-of-type > div > p:not(:has(picture)) {
@@ -36,10 +36,9 @@
   margin-bottom: var(--spacing-xlarge);
 }
 
-@media (width >= 900px) {
-  .wide main > .section {
-    max-width: 100%;
-    width: 100%;
+@media (width >= 768px) {
+  .wide main > .section .default-content-wrapper p {
+    font-size: 18px;
   }
 }
 
@@ -47,5 +46,9 @@
   .wide main > .section {
     max-width: 100%;
     width: 100%;
+  }
+
+  .wide main > .section .default-content-wrapper p {
+    font-size: 20px;
   }
 }


### PR DESCRIPTION
## Issue

Fixes #185 

feat: implement wide template with full-width layout and responsive typography

- Configure all sections to use 100% width across all breakpoints
- Remove section-level padding while maintaining content padding via grid-margin
- Ensure hero image aligns with text content on mobile and stays contained
- Add responsive font sizing for default content:
  - Mobile (< 768px): 16px
  - Tablet (768px - 1023px): 18px
  - Desktop (1024px+): 20px
- Add proper vertical spacing for headings and paragraphs in hero section
- Ensure images in first section span full container width

URLs:
- Before: https://main--extweb-academy--aemsites.aem.page/en/cross-cutting
- After: https://185-wide-template--extweb-academy--aemsites.aem.page/en/cross-cutting
- Reference: https://academy.worldbank.org/en/cross-cutting
