### PR TITLE
fix(ue): prevent infinite scroll in Universal Editor

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -987,6 +987,11 @@ html.adobe-ue-preview,
 html.adobe-ue-edit {
   height: unset;
 
+  .section.hero-video-section {
+    height: 600px;
+    min-height: 600px;
+  }
+
   .section.hero-video-section > .default-content-wrapper {
     height: 600px;
   }
@@ -996,6 +1001,16 @@ html.adobe-ue-edit {
   }
 
   .section.iframe-container > .iframe-wrapper {
+    height: 600px;
+  }
+
+  /* Override mobile vh properties - padding-bottom fix */
+  .section.hero-video-section .default-content-wrapper {
+    padding-bottom: 80px;
+  }
+
+  /* Override homepage-specific vh heights */
+  .homepage .section.hero-video-section > .default-content-wrapper {
     height: 600px;
   }
 }


### PR DESCRIPTION
fix(ue): prevent infinite scroll in Universal Editor by overriding vh units
Related to: #168 (CLS score improvements)

## Issue

Fixes #191 

- Add fixed pixel heights (600px) for hero-video-section elements in UE mode
- Override main section, video-wrapper, and default-content-wrapper heights
- Replace 10vh padding-bottom with fixed 80px for mobile layouts
- Add homepage-specific height override for default-content-wrapper

## Test URLs and instructions 

- Before: https://author-worldbank-b75-stage-comm.adobecqms.net/content/extweb-academy/index.html
- After: https://author-worldbank-b75-stage-comm.adobecqms.net/content/extweb-academy/index.html?ref=191-fix-ue-scroll
