### PR TITLE
fix(header): align nav-home mobile and desktop menu to match reference site

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -1861,7 +1861,7 @@ body:has(.header-home nav.nav-home[aria-expanded='true']) {
 
   .header-home .home-nav-links ul li {
     display: flex;
-    margin-left: 24px;
+    margin-left: 32px;
     padding: 0;
     white-space: nowrap;
     align-items: center;


### PR DESCRIPTION
## Issue

Fixes #188 

## Description

Align nav-home mobile and desktop menu to match reference site

Mobile menu improvements:
- Adjust nav padding from 16px 24px to 32px 28px for proper spacing
- Increase World Bank logo size (28px → 32px base, responsive up to 40px)
- Implement baseline alignment between logo text and Academy text using flex-end
- Add vertical divider with correct styling (2px, 24% opacity, border-right)
- Make logo responsive below 430px viewport (scales proportionally)
- Set Academy text font size to 16px (mobile) and 18px (768px+)

Desktop menu improvements:
- Remove max-width constraint on .header-home .nav-wrapper
- Set nav-wrapper max-width to 1600px for proper expansion
- Maintain 72px horizontal padding at all desktop sizes
- Fix Academy text vertical alignment at 1281px+ breakpoint
- Remove align-self: stretch and fixed height constraints
- Apply consistent baseline alignment across all breakpoints

All changes preserve mobile responsiveness and ensure pixel-perfect
alignment with reference site across all viewport sizes.


## Test URLs and instructions

- Before: https://main--extweb-academy--aemsites.aem.page/
- After: https://188-home-menu--extweb-academy--aemsites.aem.page/
