### PR TITLE
added function to automatically deduce the height of the iframe.

### DIFF
--- a/blocks/iframe/iframe.css
+++ b/blocks/iframe/iframe.css
@@ -15,7 +15,7 @@
 
 .iframe-wrapper {
   position: relative;
-  width: 100%;
+  width: auto;
   min-height: 400px;
   overflow: hidden;
 }


### PR DESCRIPTION
How it works now:
Default: Uses a 400px min-height
If explicit heights are configured via the block, those are used
If no heights are configured, the JS attempts to auto-size:
Same-origin iframes get their height measured directly
Cross-origin iframes that support it can send their height via postMessage (format: { height: number } or { frameHeight: number })

Note: For cross-origin iframes that don't send their height via postMessage, you'll need to configure the height explicitly in the block settings, as there's no way to access their content height due to browser security restrictions.

Fixes #206 

## Description of what the PR is changing, including screenshots for clarity if needed.

**New**

- JS: Added setupDynamicHeight() function that automatically adjusts the iframe height:
For same-origin iframes: measures the content height directly on load
For cross-origin iframes: listens for postMessage events (many embeddable widgets send their height this way)

**Changed**

- CSS (iframe.css):
Removed padding-bottom: 75% (the aspect ratio hack)
Changed to min-height: 400px as a sensible default
Removed position: absolute from the iframe since it's no longer needed
Removed scrolling="no" to allow scrolling if content exceeds the container
**Removed**

- 


## Test URLs and instructions -- There can be more than 1 set

> If applicable, also describe how the PR reviewer can verify your expected changes, including anything that should NOT change.

- Before: https://main--extweb-academy--aemsites.aem.page/en/our-programs/by-theme
- After: https://206-fix-map-height--extweb-academy--aemsites.aem.page/en/our-programs/by-theme
